### PR TITLE
parsing issue

### DIFF
--- a/s3breeze/main.py
+++ b/s3breeze/main.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 def xml_formatter(text):
     try:
         text = json.loads(text)
+        if type(text) is dict:
+            return None
     except json.JSONDecodeError:
         pass
     try:

--- a/s3breeze/main.py
+++ b/s3breeze/main.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 def xml_formatter(text):
     try:
         text = json.loads(text)
-        if type(text) is dict:
-            return None
+        if not isinstance(text, str):
+            return
     except json.JSONDecodeError:
         pass
     try:


### PR DESCRIPTION
If we get a valid json from s3, the following error appears in xml_formatter():
`TypeError: a bytes-like object is required, not 'dict'`
The following commit fixes the issue. 
@yevhen-m 